### PR TITLE
build(deps): Bump ocipkg from 0.2.9 to 0.3.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,6 +801,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,10 +849,11 @@ dependencies = [
 
 [[package]]
 name = "ocipkg"
-version = "0.2.9"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb3293021f06540803301af45e7ab81693d50e89a7398a3420bdab139e7ba5e"
+checksum = "2489f5079bd71743b0bfbb4a36d08665996be1205f0d9ecc083b6e4f6dc48e7e"
 dependencies = [
+ "anyhow",
  "base16ct",
  "base64",
  "chrono",
@@ -854,16 +861,17 @@ dependencies = [
  "flate2",
  "lazy_static",
  "log",
+ "maplit",
  "oci-spec",
  "regex",
  "serde",
  "serde_json",
  "sha2",
  "tar",
- "thiserror",
  "toml",
  "ureq",
  "url",
+ "urlencoding",
  "uuid",
  "walkdir",
 ]
@@ -1442,6 +1450,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf16_iter"

--- a/intel-mkl-src/Cargo.toml
+++ b/intel-mkl-src/Cargo.toml
@@ -31,7 +31,7 @@ mkl-dynamic-ilp64-seq  = []
 
 [build-dependencies]
 anyhow = "1.0.58"
-ocipkg = "0.2.9"
+ocipkg = "0.3.9"
 flate2 = "1.0.28"
 log = "0.4.21"
 tar = "0.4.40"


### PR DESCRIPTION
- Bump `ocipkg` from 0.2.9 to 0.3.9
- Use `ocipkg::image::OciArtifact::get_layers` rather than `ocipkg::distribution::get_layer_bytes`
